### PR TITLE
Fix issue with disappearing shownotes

### DIFF
--- a/shownotes.php
+++ b/shownotes.php
@@ -79,7 +79,7 @@ function save_shownotes() {
   if (isset($_POST['shownotes'])) {
     $new = $_POST['shownotes'];
   } else {
-    $new = '';
+    return;
   }
   $shownotes = $old;
   if ($new && $new != $old) {


### PR DESCRIPTION
When `$_POST['shownotes']` is not set, `save_post` must not change that post meta.
